### PR TITLE
Fix: Resolve duplicate FCM notifications on web

### DIFF
--- a/App/Hooks/useUnifiedNotifications.js
+++ b/App/Hooks/useUnifiedNotifications.js
@@ -225,13 +225,15 @@ export const useUnifiedNotifications = () => {
 
   // Configurer les notifications au montage du composant
   useEffect(() => {
-    initializeNotifications();
-    
-    // // Configurer les écouteurs de notifications
-    // const unsubscribe = unifiedNotificationService.setupNotificationListeners(
-    //   handleNotificationReceived,
-    //   handleNotificationResponse
-    // );
+    // initializeNotifications(); // This is ALREADY CALLED in its own useEffect. No need to call again.
+
+    // Configurer les écouteurs de notifications
+    // This will now correctly set up mobile listeners, and for web,
+    // the NOTIFICATION_CLICK listener from the service worker.
+    const unsubscribe = unifiedNotificationService.setupNotificationListeners(
+      handleNotificationReceived, // For in-app UI updates (e.g., badge, list)
+      handleNotificationResponse  // For handling clicks
+    );
     
     // Nettoyage à la destruction du composant
     return () => {
@@ -239,7 +241,11 @@ export const useUnifiedNotifications = () => {
         unsubscribe();
       }
     };
-  }, [initializeNotifications, handleNotificationReceived, handleNotificationResponse]);
+    // Ensure dependencies are correct. `initializeNotifications` is not directly used here,
+    // but its action (calling unifiedNotificationService.initialize) is a prerequisite.
+    // The direct dependencies are the callbacks.
+  }, [handleNotificationReceived, handleNotificationResponse]);
+  // Removed initializeNotifications from deps array as it's in its own effect.
 
   // Mettre à jour le compteur de notifications périodiquement (toutes les 30 secondes)
   useEffect(() => {


### PR DESCRIPTION
This commit addresses an issue where FCM notifications were appearing in duplicate on the web platform. The primary cause was a combination of how foreground and background messages were processed, and ineffective deduplication logic when server-side notification tags were not provided.

Changes implemented:

1.  **Improved Deduplication (`public/firebase-messaging-sw.js`):**
    *   Modified `createNotificationId` to use a server-provided
        `payload.notification.tag` if available.
    *   If no tag is provided, it now generates a more stable ID based on
        notification content (title, body) instead of a timestamp,
        enhancing the effectiveness of the `showNotificationIfNotDuplicate`
        function.

2.  **Centralized Web Notification Display:**
    *   **`App/Shared/unifiedNotificationService.js`:**
        *   Uncommented and modified the FCM `onMessageListener` (for foreground
            web messages) within the `initialize` method. This listener now
            posts a `FOREGROUND_FCM_RECEIVED` message
            instead of directly displaying a notification.
        *   Ensured the `setupNotificationListeners` method for web correctly
            listens for `NOTIFICATION_CLICK` events (for handling clicks on notifications).
    *   **`App/Hooks/useUnifiedNotifications.js`:**
        *   Uncommented the call to
            `unifiedNotificationService.setupNotificationListeners` to activate
            the foreground message pathway and click handling.
    *   **`public/firebase-messaging-sw.js`:**
        *   Updated the `message` event listener to handle the new
            `FOREGROUND_FCM_RECEIVED` type from the application. Upon
            receiving this, it uses the payload to construct and display a
            notification via the `showNotificationIfNotDuplicate` function.

These changes ensure that all web FCM notifications (both foreground and background) are ultimately displayed using
a unified and improved deduplication strategy. Native mobile notification handling remains unaffected.